### PR TITLE
fix: Container build

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   postgres:
     image: postgres:latest
@@ -19,11 +17,11 @@ services:
 
   rust_web_server:
     build:
-      context: ./path/to/your/rust/project
+      context: .
       dockerfile: Dockerfile
     depends_on:
       - postgres
-      - redis
+      # - redis
     environment:
       DATABASE_HOST: postgres
       DATABASE_PORT: 5432


### PR DESCRIPTION
This pull request updates the Docker setup for a Rust-based web server project, transitioning from Alpine Linux to Debian-based images for better compatibility with OpenSSL and simplifying the `docker-compose.yaml` configuration. Key changes include adjustments to the Dockerfile for dependency installation and runtime libraries, as well as modifications to the `docker-compose.yaml` file to streamline the service definitions.

### Dockerfile Updates:
* Switched base images from `rust:alpine3.19` and `alpine:latest` to `rust:bullseye` and `debian:bullseye-slim` for improved OpenSSL support.
* Updated dependency installation commands to use `apt-get` for Debian-based images, including `libssl-dev` and `libssl1.1` for OpenSSL compatibility.
* Adjusted file copying and build commands to align with the new directory structure and runtime environment.

### `docker-compose.yaml` Updates:
* Removed the `version` field to simplify the configuration.
* Updated the `rust_web_server` service to use the current directory as the build context and commented out the `redis` dependency for reduced complexity.switched to debian images