### PR TITLE
feat: Add password hashing utils to hash and verify passwords

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +153,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -1252,6 +1273,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2003,7 +2035,9 @@ dependencies = [
 name = "sso-oidc"
 version = "0.1.0"
 dependencies = [
+ "argon2",
  "axum",
+ "base64",
  "chrono",
  "dotenv",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2037,7 +2037,6 @@ version = "0.1.0"
 dependencies = [
  "argon2",
  "axum",
- "base64",
  "chrono",
  "dotenv",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ serde_json = "1.0.140"
 serde_with = { version = "3.14.0", features = ["json"]}
 uuid = { version = "1.17.0", features = ["serde", "v4"] }
 jsonwebtoken = "9.3.1"
+argon2 = "0.5.3"
+rand = "0.8.5"
+base64 = "0.22.1"
 
 [dev-dependencies]
 rsa = "0.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ uuid = { version = "1.17.0", features = ["serde", "v4"] }
 jsonwebtoken = "9.3.1"
 argon2 = "0.5.3"
 rand = "0.8.5"
-base64 = "0.22.1"
 
 [dev-dependencies]
 rsa = "0.7.2"

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
 pub mod database;
+pub mod password_hash_utils;
 pub mod token_issuer;
 pub mod token_verifier;

--- a/src/utils/password_hash_utils.rs
+++ b/src/utils/password_hash_utils.rs
@@ -2,7 +2,6 @@ use argon2::password_hash::{
     Error as PasswordHashError, PasswordHash, SaltString, rand_core::OsRng,
 };
 use argon2::{Argon2, PasswordHasher, PasswordVerifier};
-use base64::{Engine, engine::general_purpose};
 
 /// Hashes a password with a new random salt.
 /// Returns (salt, password_hash)

--- a/src/utils/password_hash_utils.rs
+++ b/src/utils/password_hash_utils.rs
@@ -1,0 +1,81 @@
+use argon2::password_hash::{
+    Error as PasswordHashError, PasswordHash, SaltString, rand_core::OsRng,
+};
+use argon2::{Argon2, PasswordHasher, PasswordVerifier};
+use base64::{Engine, engine::general_purpose};
+
+/// Hashes a password with a new random salt.
+/// Returns (salt, password_hash)
+pub fn hash_password(password: &str) -> Result<(String, String), PasswordHashError> {
+    let salt = SaltString::generate(&mut OsRng);
+    let argon2 = Argon2::default();
+
+    let hash = argon2
+        .hash_password(password.as_bytes(), &salt)?
+        .to_string();
+
+    Ok((salt.to_string(), hash))
+}
+
+/// Verifies a password against its hash and salt
+pub fn verify_password(password: &str, password_hash: &str) -> Result<bool, PasswordHashError> {
+    let parsed_hash = PasswordHash::new(password_hash)?;
+    let argon2 = Argon2::default();
+
+    Ok(argon2
+        .verify_password(password.as_bytes(), &parsed_hash)
+        .is_ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash_and_verify_success() {
+        let password = "original-password";
+        let (_salt, hash) = hash_password(password).expect("hashing failed");
+
+        let is_valid = verify_password(password, &hash).expect("verification failed");
+        assert!(is_valid, "Password should validate successfully");
+    }
+
+    #[test]
+    fn test_verify_fails_on_wrong_password() {
+        let password = "original-password";
+        let wrong_password = "wrong-password";
+
+        let (_salt, hash) = hash_password(password).expect("hashing failed");
+
+        let is_valid = verify_password(wrong_password, &hash).expect("verification failed");
+        assert!(!is_valid, "Wrong password should not validate");
+    }
+
+    #[test]
+    fn test_verify_fails_on_tampered_hash() {
+        let password = "password123";
+        let (_salt, mut hash) = hash_password(password).expect("hashing failed");
+
+        // Tamper the hash string (e.g., change one character)
+        hash.replace_range(10..11, "x");
+
+        let result = verify_password(password, &hash);
+        assert!(
+            result.is_err() || !result.unwrap(),
+            "Tampered hash should not verify"
+        );
+    }
+
+    #[test]
+    fn test_multiple_hashes_are_different() {
+        let password = "same-password";
+
+        let (_, hash1) = hash_password(password).expect("hashing failed");
+        let (_, hash2) = hash_password(password).expect("hashing failed");
+
+        assert_ne!(
+            hash1, hash2,
+            "Hashes for same password should differ due to random salt"
+        );
+    }
+}


### PR DESCRIPTION
This pull request introduces functionality for password hashing and verification using the Argon2 algorithm. It includes updates to dependencies, modularization of utility code, and comprehensive tests for the new functionality.

### Dependency Updates:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R18-R20): Added `argon2`, `rand`, and `base64` dependencies to support password hashing and random salt generation.

### Code Modularization:
* [`src/utils/mod.rs`](diffhunk://#diff-d3df0754141e5e2476f0425ab90722412a0348dec6263b76a9024970e822e816R2): Added a new module `password_hash_utils` to organize password hashing-related utilities.

### Password Hashing and Verification Implementation:
* [`src/utils/password_hash_utils.rs`](diffhunk://#diff-4077a5b09a419b5178f4b898351b784061e0ebc788c80520c5598e6dab09a699R1-R81): Implemented `hash_password` and `verify_password` functions using `argon2` for secure password handling. Includes detailed inline documentation for each function.

### Unit Tests:
* [`src/utils/password_hash_utils.rs`](diffhunk://#diff-4077a5b09a419b5178f4b898351b784061e0ebc788c80520c5598e6dab09a699R1-R81): Added comprehensive test cases to ensure correct functionality of password hashing and verification, including edge cases like tampered hashes and repeated hashing of the same password.